### PR TITLE
Return a Promise if callback is not defined in .read() and .write()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var func = require('x-is-function');
 var vfile = require('./core');
 
 module.exports = vfile;
@@ -14,19 +15,33 @@ vfile.writeSync = writeSync;
 function read(description, options, callback) {
   var file = vfile(description);
 
-  if (!callback) {
+  if (!callback && func(options)) {
     callback = options;
     options = null;
   }
 
-  fs.readFile(file.path, options, function (err, res) {
-    if (err) {
-      callback(err);
-    } else {
-      file.contents = res;
-      callback(null, file);
+  if (!callback) {
+    return new Promise(executor);
+  }
+
+  executor(null, callback);
+
+  function executor(resolve, reject) {
+    fs.readFile(file.path, options, done);
+
+    function done(err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        file.contents = res;
+        if (resolve) {
+          resolve(file);
+        } else {
+          callback(null, file);
+        }
+      }
     }
-  });
+  }
 }
 
 /* Create a virtual file and read it in, synchronously. */
@@ -41,12 +56,30 @@ function write(description, options, callback) {
   var file = vfile(description);
 
   /* Weird, right? Otherwise `fs` doesn’t accept it. */
-  if (!callback) {
+  if (!callback && func(options)) {
     callback = options;
     options = undefined;
   }
 
-  fs.writeFile(file.path, file.contents || '', options, callback);
+  if (!callback) {
+    return new Promise(executor);
+  }
+
+  executor(null, callback);
+
+  function executor(resolve, reject) {
+    fs.writeFile(file.path, file.contents || '', options, done);
+
+    function done(err, res) {
+      if (err) {
+        reject(err);
+      } else if (resolve) {
+        resolve(res);
+      } else {
+        callback(null, res);
+      }
+    }
+  }
 }
 
 /* Create a virtual file and write it out, synchronously. */

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -34,6 +34,7 @@ function read(description, options, callback) {
         reject(err);
       } else {
         file.contents = res;
+
         if (resolve) {
           resolve(file);
         } else {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -71,13 +71,13 @@ function write(description, options, callback) {
   function executor(resolve, reject) {
     fs.writeFile(file.path, file.contents || '', options, done);
 
-    function done(err, res) {
+    function done(err) {
       if (err) {
         reject(err);
       } else if (resolve) {
-        resolve(res);
+        resolve();
       } else {
-        callback(null, res);
+        callback();
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "dependencies": {
     "is-buffer": "^1.1.4",
-    "vfile": "^2.0.0"
+    "vfile": "^2.0.0",
+    "x-is-function": "^1.0.4"
   },
   "devDependencies": {
     "browserify": "^14.0.0",

--- a/readme.md
+++ b/readme.md
@@ -58,8 +58,10 @@ it’s treated as `{path: options}` instead of `{contents: options}`.
 Creates a virtual file from options (`toVFile(options)`), reads the
 file from the file-system and populates `file.contents` with the result.
 If `encoding` is specified, it’s passed to `fs.readFile`.
-Invokes `callback` with either an error or the populated virtual file.
-When callback is not defined, returns a Promise.
+If `callback` is given, invokes it with either an error or the populated
+virtual file.
+If `callback` is not given, returns a [`Promise`][promise] that is
+rejected with an error or resolved with the populated virtual file.
 
 ### `toVFile.readSync(options[, encoding])`
 
@@ -70,8 +72,9 @@ returns a populated virtual file.
 
 Creates a virtual file from `options` (`toVFile(options)`), writes the
 file to the file-system.  `fsOptions` are passed to `fs.writeFile`.
-Invokes `callback` with an error, if any.
-When callback is not defined, returns a Promise.
+If `callback` is given, invokes it with an error, if any.
+If `callback` is not given, returns a [`Promise`][promise] that is
+rejected with an error or resolved without any value.
 
 ### `toVFile.writeSync(options[, fsOptions])`
 
@@ -105,6 +108,8 @@ repository, organisation, or community you agree to abide by its terms.
 [author]: http://wooorm.com
 
 [vfile]: https://github.com/vfile/vfile
+
+[promise]: https://developer.mozilla.org/Web/JavaScript/Reference/Global_Objects/Promise
 
 [contribute]: https://github.com/vfile/vfile/blob/master/contributing.md
 

--- a/readme.md
+++ b/readme.md
@@ -53,23 +53,25 @@ Create a virtual file.  Works like the [vfile][] constructor,
 except when `options` is `string` or `Buffer`, in which case
 it’s treated as `{path: options}` instead of `{contents: options}`.
 
-### `toVFile.read(options[, encoding], callback)`
+### `toVFile.read(options[, encoding][, callback])`
 
 Creates a virtual file from options (`toVFile(options)`), reads the
 file from the file-system and populates `file.contents` with the result.
 If `encoding` is specified, it’s passed to `fs.readFile`.
 Invokes `callback` with either an error or the populated virtual file.
+When callback is not defined, returns a Promise.
 
 ### `toVFile.readSync(options[, encoding])`
 
 Like `toVFile.read` but synchronous.  Either throws an error or
 returns a populated virtual file.
 
-### `toVFile.write(options[, fsOptions], callback)`
+### `toVFile.write(options[, fsOptions][, callback])`
 
 Creates a virtual file from `options` (`toVFile(options)`), writes the
 file to the file-system.  `fsOptions` are passed to `fs.writeFile`.
 Invokes `callback` with an error, if any.
+When callback is not defined, returns a Promise.
 
 ### `toVFile.writeSync(options[, fsOptions])`
 

--- a/test.js
+++ b/test.js
@@ -44,8 +44,6 @@ test('toVFile()', function (t) {
     st.equal(file.contents, undefined);
     st.end();
   });
-
-  t.end();
 });
 
 test('toVFile.readSync', function (t) {
@@ -74,8 +72,6 @@ test('toVFile.readSync', function (t) {
     /ENOENT/,
     'should throw on non-existing files'
   );
-
-  t.end();
 });
 
 test('toVFile.read', function (t) {
@@ -196,8 +192,6 @@ test('toVFile.writeSync', function (t) {
     /ENOENT/,
     'should throw on files that cannot be written'
   );
-
-  t.end();
 });
 
 test('toVFile.write', function (t) {

--- a/test.js
+++ b/test.js
@@ -100,7 +100,7 @@ test('toVFile.read', function (t) {
         st.equal(file.toString(), fixture);
       })
       .catch(function () {
-        t.fail('should resolve, not reject');
+        st.fail('should resolve, not reject');
       });
   });
 


### PR DESCRIPTION
Closes #4 

Using the same approach for supporting both callbacks and promises as in [unified](https://github.com/unifiedjs/unified/blob/470ed8020e2f16c8af40ff63e81792268662faf4/index.js#L292-L311).