### PR TITLE
Honor file.cwd for filesystem I/O operations

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var fs = require('fs')
+var path = require('path')
 var vfile = require('./core')
 
 module.exports = vfile
@@ -26,7 +27,7 @@ function read(description, options, callback) {
   executor(null, callback)
 
   function executor(resolve, reject) {
-    fs.readFile(file.path, options, done)
+    fs.readFile(resolvePath(file), options, done)
 
     function done(err, res) {
       if (err) {
@@ -47,7 +48,7 @@ function read(description, options, callback) {
 /* Create a virtual file and read it in, synchronously. */
 function readSync(description, options) {
   var file = vfile(description)
-  file.contents = fs.readFileSync(file.path, options)
+  file.contents = fs.readFileSync(resolvePath(file), options)
   return file
 }
 
@@ -68,7 +69,7 @@ function write(description, options, callback) {
   executor(null, callback)
 
   function executor(resolve, reject) {
-    fs.writeFile(file.path, file.contents || '', options, done)
+    fs.writeFile(resolvePath(file), file.contents || '', options, done)
 
     function done(err) {
       if (err) {
@@ -85,5 +86,10 @@ function write(description, options, callback) {
 /* Create a virtual file and write it out, synchronously. */
 function writeSync(description, options) {
   var file = vfile(description)
-  fs.writeFileSync(file.path, file.contents || '', options)
+  fs.writeFileSync(resolvePath(file), file.contents || '', options)
+}
+
+/* Resolve the vfile's path, taking into consideration its .path and .cwd */
+function resolvePath(file) {
+  return path.isAbsolute(file.path) ? file.path : path.join(file.cwd, file.path)
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -27,7 +27,7 @@ function read(description, options, callback) {
   executor(null, callback)
 
   function executor(resolve, reject) {
-    fs.readFile(resolvePath(file), options, done)
+    fs.readFile(path.resolve(file.cwd, file.path), options, done)
 
     function done(err, res) {
       if (err) {
@@ -48,7 +48,7 @@ function read(description, options, callback) {
 /* Create a virtual file and read it in, synchronously. */
 function readSync(description, options) {
   var file = vfile(description)
-  file.contents = fs.readFileSync(resolvePath(file), options)
+  file.contents = fs.readFileSync(path.resolve(file.cwd, file.path), options)
   return file
 }
 
@@ -69,7 +69,12 @@ function write(description, options, callback) {
   executor(null, callback)
 
   function executor(resolve, reject) {
-    fs.writeFile(resolvePath(file), file.contents || '', options, done)
+    fs.writeFile(
+      path.resolve(file.cwd, file.path),
+      file.contents || '',
+      options,
+      done
+    )
 
     function done(err) {
       if (err) {
@@ -86,10 +91,9 @@ function write(description, options, callback) {
 /* Create a virtual file and write it out, synchronously. */
 function writeSync(description, options) {
   var file = vfile(description)
-  fs.writeFileSync(resolvePath(file), file.contents || '', options)
-}
-
-/* Resolve the vfile's path, taking into consideration its .path and .cwd */
-function resolvePath(file) {
-  return path.isAbsolute(file.path) ? file.path : path.join(file.cwd, file.path)
+  fs.writeFileSync(
+    path.resolve(file.cwd, file.path),
+    file.contents || '',
+    options
+  )
 }

--- a/test.js
+++ b/test.js
@@ -88,6 +88,23 @@ test('toVFile.readSync', function(t) {
     st.end()
   })
 
+  t.test(
+    'should honor file.cwd when file.path is relative, even with relative cwd',
+    function(st) {
+      var file = vfile.readSync(
+        {
+          path: 'core.js',
+          cwd: 'lib'
+        },
+        'utf8'
+      )
+
+      st.equal(typeof file.contents, 'string')
+
+      st.end()
+    }
+  )
+
   t.throws(
     function() {
       vfile.readSync({

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var fs = require('fs')
+var path = require('path')
 var test = require('tape')
 var buffer = require('is-buffer')
 var vfile = require('.')
@@ -71,6 +72,31 @@ test('toVFile.readSync', function(t) {
     },
     /ENOENT/,
     'should throw on non-existing files'
+  )
+
+  t.test('should honor file.cwd when file.path is relative', function(st) {
+    var file = vfile.readSync(
+      {
+        path: 'core.js',
+        cwd: path.join(process.cwd(), 'lib')
+      },
+      'utf8'
+    )
+
+    st.equal(typeof file.contents, 'string')
+
+    st.end()
+  })
+
+  t.throws(
+    function() {
+      vfile.readSync({
+        path: path.join(process.cwd(), 'core.js'),
+        cwd: path.join(process.cwd(), 'lib')
+      })
+    },
+    /ENOENT/,
+    'should ignore file.cwd when file.path is absolute'
   )
 })
 


### PR DESCRIPTION
Fixes #6 — when the vfile has a relative `path` property, take into account its `cwd` propertry (usually it will be `process.cwd()` but can be specified by the user) to build the path. For absolute paths, ignore the `cwd`.