### PR TITLE
Replace reserved word `async`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,12 +1,12 @@
 'use strict'
 
 var vfile = require('./core')
-var sync = require('./sync')
-var async = require('./async')
+var fsSync = require('./sync')
+var fsAsync = require('./async')
 
 module.exports = vfile
 
-vfile.read = async.read
-vfile.readSync = sync.read
-vfile.write = async.write
-vfile.writeSync = sync.write
+vfile.read = fsAsync.read
+vfile.readSync = fsSync.read
+vfile.write = fsAsync.write
+vfile.writeSync = fsSync.write


### PR DESCRIPTION
Replaces the reserved variable name `async` which might lead to errors in newer NodeJS versions.
Variable `sync` is replaced to keep uniformity.