### PR TITLE
Fix `Buffer` type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,9 @@
  * @typedef {BufferEncoding|{encoding?: null|BufferEncoding, flag?: string}} ReadOptions
  * @typedef {BufferEncoding|{encoding?: null|BufferEncoding, mode: Mode?, flag?: string}} WriteOptions
  *
- * @typedef {Value|URL|Options|VFile} Compatible Things that can be
+ * @typedef {URL|Value} Path Path of the file.
+ *   Note: `Value` is used here because it’s a smarter `Buffer`
+ * @typedef {Path|Options|VFile} Compatible Things that can be
  *   passed to the function.
  */
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,7 @@
  * @typedef {BufferEncoding|{encoding?: null|BufferEncoding, flag?: string}} ReadOptions
  * @typedef {BufferEncoding|{encoding?: null|BufferEncoding, mode: Mode?, flag?: string}} WriteOptions
  *
- * @typedef {string|Uint8Array} Path Path of the file.
- * @typedef {Path|URL|Options|VFile} Compatible Things that can be
+ * @typedef {Value|URL|Options|VFile} Compatible Things that can be
  *   passed to the function.
  */
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

According to the types a Uint8Array was accepted as a path. However, only a string is accepted as a path. A buffer is allowed too.

The `Path` type has ben removed. Instead `Compatible` now accepts `VFileValue`, which can be either string or Buffer.

<!--do not edit: pr-->
